### PR TITLE
Fehler in Readme Datei beheben

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
       </ul>
     </li>
   </ol>
+</details>
 
 ## About The Project
 This extension wraps SUSHI (FHIR Shorthand) and the HAPI Validator, providing comprehensive warning and error messages. It allows you to "run" your .fsh shorthand files to both generate FHIR .json files and validate them simultaneously.


### PR DESCRIPTION
Fehler in der README-Datei beheben, wo der Inhalt erst angezeigt wird, wenn man das Inhaltsverzeichnis aufklappt.